### PR TITLE
[step1] Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # jpa-bootstrap
+
+## 1단계 - Metadata
+### 요구사항 1 - @Entity 엔터티 어노테이션이 있는 클래스만 가져오기
+- AnnotationBinder
+  - 상위패키지에 있는 @Entity가 달린 클래스를 모두 scan한다.
+  - Metamodel에 해당 값을 모두 채워준다. 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@
 ### 요구사항 1 - @Entity 엔터티 어노테이션이 있는 클래스만 가져오기
 - AnnotationBinder
   - 상위패키지에 있는 @Entity가 달린 클래스를 모두 scan한다.
-  - Metamodel에 해당 값을 모두 채워준다. 
+  - 패키지에 클래스를 찾을 수 없는 경우 빈 list를 반환한다.
+  - 패키지에 entity 클래스를 찾을 수 없는 경우 빈 list를 반환한다.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@
 - MetaModel
   - AnnotationBinder를 통해 값을 세팅할 수 있다.
     - Map<Class<?>, EntityClass> entityClassMap = new ConcurrentHashMap<>();
+  - 특정 Class를 받아 EntityClass를 반환할 수 있다.
+    - 없는 EntityClass인 경우 예외가 발생한다.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@
   - 상위패키지에 있는 @Entity가 달린 클래스를 모두 scan한다.
   - 패키지에 클래스를 찾을 수 없는 경우 빈 list를 반환한다.
   - 패키지에 entity 클래스를 찾을 수 없는 경우 빈 list를 반환한다.
+
+### 요구사항 2 - scanner 로 찾은 Entity Class 정보를 통해 MetamodelImpl 에 데이터를 채워넣어보자
+- MetaModel
+  - AnnotationBinder를 통해 값을 세팅할 수 있다.
+    - Map<Class<?>, EntityClass> entityClassMap = new ConcurrentHashMap<>();

--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@
 - MetaModel
   - AnnotationBinder를 통해 값을 세팅할 수 있다.
     - Map<Class<?>, EntityClass> entityClassMap = new ConcurrentHashMap<>();
-  - 특정 Class를 받아 EntityClass를 반환할 수 있다.
+    - Map<Class<?>, EntityPersister<?>> entityPersisterMap;
+    - Map<Class<?>, EntityLoader<?>> entityLoaderMap;
+  - 특정 Class를 받아 Entity 어노테이션을 통해 만든 map의 value를 반환한다.
     - 없는 EntityClass인 경우 예외가 발생한다.

--- a/src/main/java/hibernate/binder/AnnotationBinder.java
+++ b/src/main/java/hibernate/binder/AnnotationBinder.java
@@ -12,7 +12,7 @@ public class AnnotationBinder {
     private AnnotationBinder() {
     }
 
-    public static List<Class<?>> parseEntityClasses(String basePackage) throws ClassNotFoundException {
+    public static List<Class<?>> parseEntityClasses(String basePackage) {
         List<Class<?>> classes = ComponentScanner.scan(basePackage);
         return classes.stream()
                 .filter(clazz -> clazz.isAnnotationPresent(ENTITY_ANNOTATION))

--- a/src/main/java/hibernate/binder/AnnotationBinder.java
+++ b/src/main/java/hibernate/binder/AnnotationBinder.java
@@ -1,0 +1,21 @@
+package hibernate.binder;
+
+import jakarta.persistence.Entity;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AnnotationBinder {
+
+    private static final Class<Entity> ENTITY_ANNOTATION = Entity.class;
+
+    private AnnotationBinder() {
+    }
+
+    public static List<Class<?>> parseEntityClasses(String basePackage) throws ClassNotFoundException {
+        List<Class<?>> classes = ComponentScanner.scan(basePackage);
+        return classes.stream()
+                .filter(clazz -> clazz.isAnnotationPresent(ENTITY_ANNOTATION))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/hibernate/binder/ComponentScanner.java
+++ b/src/main/java/hibernate/binder/ComponentScanner.java
@@ -1,0 +1,29 @@
+package hibernate.binder;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ComponentScanner {
+
+    private ComponentScanner() {
+    }
+
+    public static List<Class<?>> scan(String basePackage) throws ClassNotFoundException {
+        List<Class<?>> classes = new ArrayList<>();
+        String path = basePackage.replace(".", "/");
+        File baseDir = new File(Thread.currentThread().getContextClassLoader().getResource(path).getFile());
+
+        if (baseDir.exists() && baseDir.isDirectory()) {
+            for (File file : baseDir.listFiles()) {
+                if (file.isDirectory()) {
+                    classes.addAll(scan(basePackage + "." + file.getName()));
+                } else if (file.getName().endsWith(".class")) {
+                    String className = basePackage + "." + file.getName().substring(0, file.getName().length() - 6);
+                    classes.add(Class.forName(className));
+                }
+            }
+        }
+        return classes;
+    }
+}

--- a/src/main/java/hibernate/binder/ComponentScanner.java
+++ b/src/main/java/hibernate/binder/ComponentScanner.java
@@ -1,6 +1,7 @@
 package hibernate.binder;
 
 import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,10 +10,16 @@ public class ComponentScanner {
     private ComponentScanner() {
     }
 
-    public static List<Class<?>> scan(String basePackage) throws ClassNotFoundException {
+    public static List<Class<?>> scan(String basePackage) {
         List<Class<?>> classes = new ArrayList<>();
         String path = basePackage.replace(".", "/");
-        File baseDir = new File(Thread.currentThread().getContextClassLoader().getResource(path).getFile());
+
+        URL resource = Thread.currentThread().getContextClassLoader().getResource(path);
+        if (resource == null) {
+            return List.of();
+        }
+
+        File baseDir = new File(resource.getFile());
 
         if (baseDir.exists() && baseDir.isDirectory()) {
             for (File file : baseDir.listFiles()) {
@@ -20,10 +27,18 @@ public class ComponentScanner {
                     classes.addAll(scan(basePackage + "." + file.getName()));
                 } else if (file.getName().endsWith(".class")) {
                     String className = basePackage + "." + file.getName().substring(0, file.getName().length() - 6);
-                    classes.add(Class.forName(className));
+                    classes.add(parseClassByName(className));
                 }
             }
         }
         return classes;
+    }
+
+    private static Class<?> parseClassByName(String className)  {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("클래스를 찾을 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/hibernate/entity/EntityManagerImpl.java
+++ b/src/main/java/hibernate/entity/EntityManagerImpl.java
@@ -34,7 +34,7 @@ public class EntityManagerImpl implements EntityManager {
             return (T) persistenceContextEntity;
         }
 
-        EntityClass<T> entityClass = EntityClass.getInstance(clazz);
+        EntityClass<T> entityClass = new EntityClass<>(clazz);
         T loadEntity = entityLoader.find(entityClass, id);
         persistenceContext.addEntity(id, loadEntity, LOADING);
         return loadEntity;
@@ -42,7 +42,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public void persist(final Object entity) {
-        EntityColumn entityId = EntityClass.getInstance(entity.getClass())
+        EntityColumn entityId = new EntityClass<>(entity.getClass())
                 .getEntityId();
         Object id = entityId.getFieldValue(entity);
         if (id == null) {
@@ -62,7 +62,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public void merge(final Object entity) {
-        EntityClass<?> entityClass = EntityClass.getInstance(entity.getClass());
+        EntityClass<?> entityClass = new EntityClass<>(entity.getClass());
         Object entityId = getNotNullEntityId(entityClass, entity);
         Map<EntityColumn, Object> changedColumns = getSnapshot(entity, entityId).changedColumns(entity);
         if (changedColumns.isEmpty()) {

--- a/src/main/java/hibernate/entity/EntityManagerImpl.java
+++ b/src/main/java/hibernate/entity/EntityManagerImpl.java
@@ -1,6 +1,5 @@
 package hibernate.entity;
 
-import hibernate.entity.meta.EntityClass;
 import hibernate.entity.meta.column.EntityColumn;
 import hibernate.entity.persistencecontext.EntityKey;
 import hibernate.entity.persistencecontext.EntitySnapshot;
@@ -41,8 +40,7 @@ public class EntityManagerImpl implements EntityManager {
     @Override
     public void persist(final Object entity) {
         EntityPersister<?> entityPersister = metaModel.getEntityPersister(entity.getClass());
-        EntityColumn entityId = metaModel.getEntityClass(entity.getClass())
-                .getEntityId();
+        EntityColumn entityId = metaModel.getEntityId(entity.getClass());
         Object id = entityId.getFieldValue(entity);
         if (id == null) {
             persistenceContext.addEntityEntry(entity, SAVING);
@@ -61,8 +59,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public void merge(final Object entity) {
-        EntityClass<?> entityClass = metaModel.getEntityClass(entity.getClass());
-        Object entityId = getNotNullEntityId(entityClass, entity);
+        Object entityId = getNotNullEntityId(entity);
         Map<EntityColumn, Object> changedColumns = getSnapshot(entity, entityId).changedColumns(entity);
         if (changedColumns.isEmpty()) {
             return;
@@ -72,8 +69,8 @@ public class EntityManagerImpl implements EntityManager {
                 .update(entityId, changedColumns);
     }
 
-    private Object getNotNullEntityId(final EntityClass<?> entityClass, final Object entity) {
-        Object entityId = entityClass.getEntityId()
+    private Object getNotNullEntityId(final Object entity) {
+        Object entityId = metaModel.getEntityId(entity.getClass())
                 .getFieldValue(entity);
         if (entityId == null) {
             throw new IllegalStateException("id가 없는 entity는 merge할 수 없습니다.");

--- a/src/main/java/hibernate/entity/EntityManagerImpl.java
+++ b/src/main/java/hibernate/entity/EntityManagerImpl.java
@@ -5,6 +5,7 @@ import hibernate.entity.meta.column.EntityColumn;
 import hibernate.entity.persistencecontext.EntityKey;
 import hibernate.entity.persistencecontext.EntitySnapshot;
 import hibernate.entity.persistencecontext.PersistenceContext;
+import hibernate.metamodel.MetaModel;
 
 import java.util.Map;
 
@@ -15,15 +16,18 @@ public class EntityManagerImpl implements EntityManager {
     private final EntityPersister entityPersister;
     private final EntityLoader entityLoader;
     private final PersistenceContext persistenceContext;
+    private final MetaModel metaModel;
 
     public EntityManagerImpl(
             final EntityPersister entityPersister,
             final EntityLoader entityLoader,
-            final PersistenceContext persistenceContext
+            final PersistenceContext persistenceContext,
+            final MetaModel metaModel
     ) {
         this.entityPersister = entityPersister;
         this.entityLoader = entityLoader;
         this.persistenceContext = persistenceContext;
+        this.metaModel = metaModel;
     }
 
     @Override

--- a/src/main/java/hibernate/entity/EntityManagerImpl.java
+++ b/src/main/java/hibernate/entity/EntityManagerImpl.java
@@ -38,7 +38,7 @@ public class EntityManagerImpl implements EntityManager {
             return (T) persistenceContextEntity;
         }
 
-        EntityClass<T> entityClass = new EntityClass<>(clazz);
+        EntityClass<T> entityClass = metaModel.getEntityClass(clazz);
         T loadEntity = entityLoader.find(entityClass, id);
         persistenceContext.addEntity(id, loadEntity, LOADING);
         return loadEntity;
@@ -46,7 +46,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public void persist(final Object entity) {
-        EntityColumn entityId = new EntityClass<>(entity.getClass())
+        EntityColumn entityId = metaModel.getEntityClass(entity.getClass())
                 .getEntityId();
         Object id = entityId.getFieldValue(entity);
         if (id == null) {
@@ -66,7 +66,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public void merge(final Object entity) {
-        EntityClass<?> entityClass = new EntityClass<>(entity.getClass());
+        EntityClass<?> entityClass = metaModel.getEntityClass(entity.getClass());
         Object entityId = getNotNullEntityId(entityClass, entity);
         Map<EntityColumn, Object> changedColumns = getSnapshot(entity, entityId).changedColumns(entity);
         if (changedColumns.isEmpty()) {

--- a/src/main/java/hibernate/entity/EntityPersister.java
+++ b/src/main/java/hibernate/entity/EntityPersister.java
@@ -9,18 +9,21 @@ import jdbc.JdbcTemplate;
 
 import java.util.Map;
 
-public class EntityPersister {
+public class EntityPersister<T> {
 
     private final JdbcTemplate jdbcTemplate;
+    private final EntityClass<T> entityClass;
+
     private final InsertQueryBuilder insertQueryBuilder = InsertQueryBuilder.INSTANCE;
     private final DeleteQueryBuilder deleteQueryBuilder = DeleteQueryBuilder.INSTANCE;
     private final UpdateQueryBuilder updateQueryBuilder = UpdateQueryBuilder.INSTANCE;
 
-    public EntityPersister(final JdbcTemplate jdbcTemplate) {
+    public EntityPersister(final JdbcTemplate jdbcTemplate, final EntityClass<T> entityClass) {
         this.jdbcTemplate = jdbcTemplate;
+        this.entityClass = entityClass;
     }
 
-    public boolean update(final EntityClass<?> entityClass, final Object entityId, final Map<EntityColumn, Object> updateFields) {
+    public boolean update(final Object entityId, final Map<EntityColumn, Object> updateFields) {
         final String query = updateQueryBuilder.generateQuery(
                 entityClass.tableName(),
                 updateFields,
@@ -31,7 +34,6 @@ public class EntityPersister {
     }
 
     public Object insert(final Object entity) {
-        EntityClass<?> entityClass = new EntityClass<>(entity.getClass());
         final String query = insertQueryBuilder.generateQuery(
                 entityClass.tableName(),
                 entityClass.getFieldValues(entity)
@@ -40,7 +42,6 @@ public class EntityPersister {
     }
 
     public void delete(final Object entity) {
-        EntityClass<?> entityClass = new EntityClass<>(entity.getClass());
         EntityColumn entityId = entityClass.getEntityId();
         final String query = deleteQueryBuilder.generateQuery(
                 entityClass.tableName(),

--- a/src/main/java/hibernate/entity/EntityPersister.java
+++ b/src/main/java/hibernate/entity/EntityPersister.java
@@ -31,7 +31,7 @@ public class EntityPersister {
     }
 
     public Object insert(final Object entity) {
-        EntityClass<?> entityClass = EntityClass.getInstance(entity.getClass());
+        EntityClass<?> entityClass = new EntityClass<>(entity.getClass());
         final String query = insertQueryBuilder.generateQuery(
                 entityClass.tableName(),
                 entityClass.getFieldValues(entity)
@@ -40,7 +40,7 @@ public class EntityPersister {
     }
 
     public void delete(final Object entity) {
-        EntityClass<?> entityClass = EntityClass.getInstance(entity.getClass());
+        EntityClass<?> entityClass = new EntityClass<>(entity.getClass());
         EntityColumn entityId = entityClass.getEntityId();
         final String query = deleteQueryBuilder.generateQuery(
                 entityClass.tableName(),

--- a/src/main/java/hibernate/entity/collection/AbstractPersistCollection.java
+++ b/src/main/java/hibernate/entity/collection/AbstractPersistCollection.java
@@ -11,9 +11,9 @@ public abstract class AbstractPersistCollection<T> implements Collection<T> {
     protected Collection<T> values = null;
     protected boolean isLoaded = false;
     protected final EntityClass<T> entityClass;
-    protected final EntityLoader entityLoader;
+    protected final EntityLoader<T> entityLoader;
 
-    protected AbstractPersistCollection(final EntityClass<T> entityClass, final EntityLoader entityLoader) {
+    protected AbstractPersistCollection(final EntityClass<T> entityClass, final EntityLoader<T> entityLoader) {
         this.entityClass = entityClass;
         this.entityLoader = entityLoader;
     }
@@ -22,7 +22,7 @@ public abstract class AbstractPersistCollection<T> implements Collection<T> {
         if (isLoaded) {
             return;
         }
-        values = entityLoader.findAll(entityClass);
+        values = entityLoader.findAll();
         isLoaded = true;
     }
 

--- a/src/main/java/hibernate/entity/meta/EntityClass.java
+++ b/src/main/java/hibernate/entity/meta/EntityClass.java
@@ -19,17 +19,13 @@ public class EntityClass<T> {
     private final EntityColumns entityColumns;
     private final Class<T> clazz;
 
-    private EntityClass(final Class<T> clazz) {
+    public EntityClass(final Class<T> clazz) {
         if (!clazz.isAnnotationPresent(Entity.class)) {
             throw new IllegalArgumentException("Entity 어노테이션이 없는 클래스는 입력될 수 없습니다.");
         }
         this.tableName = new EntityTableName(clazz);
         this.entityColumns = new EntityColumns(clazz.getDeclaredFields());
         this.clazz = clazz;
-    }
-
-    public static <T> EntityClass<T> getInstance(final Class<T> clazz) {
-        return (EntityClass<T>) CACHE.computeIfAbsent(clazz, EntityClass::new);
     }
 
     public T newInstance()  {

--- a/src/main/java/hibernate/entity/meta/EntityClass.java
+++ b/src/main/java/hibernate/entity/meta/EntityClass.java
@@ -9,11 +9,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityClass<T> {
-
-    private static final Map<Class<?>, EntityClass<?>> CACHE = new ConcurrentHashMap<>();
 
     private final EntityTableName tableName;
     private final EntityColumns entityColumns;

--- a/src/main/java/hibernate/entity/meta/column/EntityField.java
+++ b/src/main/java/hibernate/entity/meta/column/EntityField.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Transient;
 
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 public class EntityField implements EntityColumn {
 
@@ -92,5 +93,18 @@ public class EntityField implements EntityColumn {
     @Override
     public GenerationType getGenerationType() {
         throw new IllegalStateException("일반 Field는 GenerationType을 호출할 수 없습니다.");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EntityField that = (EntityField) o;
+        return Objects.equals(field, that.field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field);
     }
 }

--- a/src/main/java/hibernate/entity/meta/column/EntityId.java
+++ b/src/main/java/hibernate/entity/meta/column/EntityId.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 public class EntityId implements EntityColumn {
 
@@ -59,5 +60,18 @@ public class EntityId implements EntityColumn {
     @Override
     public GenerationType getGenerationType() {
         return generationType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EntityId entityId = (EntityId) o;
+        return Objects.equals(entityField, entityId.entityField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entityField);
     }
 }

--- a/src/main/java/hibernate/entity/meta/column/EntityOneToManyColumn.java
+++ b/src/main/java/hibernate/entity/meta/column/EntityOneToManyColumn.java
@@ -24,7 +24,7 @@ public class EntityOneToManyColumn implements EntityJoinColumn {
         this.fieldName = parseFieldName(field);
         this.fetchType = field.getAnnotation(OneToMany.class)
                 .fetch();
-        this.entityClass = EntityClass.getInstance((Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0]);
+        this.entityClass = new EntityClass<>((Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0]);
         this.field = field;
     }
 

--- a/src/main/java/hibernate/entity/persistencecontext/EntityKey.java
+++ b/src/main/java/hibernate/entity/persistencecontext/EntityKey.java
@@ -11,7 +11,7 @@ public class EntityKey {
 
     public EntityKey(final Object id, final Class<?> clazz) {
         this.id = id;
-        this.entityClass = EntityClass.getInstance(clazz);
+        this.entityClass = new EntityClass<>(clazz);
     }
 
     public EntityKey(final Object id, final Object object) {

--- a/src/main/java/hibernate/entity/persistencecontext/EntityKey.java
+++ b/src/main/java/hibernate/entity/persistencecontext/EntityKey.java
@@ -1,17 +1,15 @@
 package hibernate.entity.persistencecontext;
 
-import hibernate.entity.meta.EntityClass;
-
 import java.util.Objects;
 
 public class EntityKey {
 
     private final Object id;
-    private final EntityClass<?> entityClass;
+    private final Class<?> clazz;
 
     public EntityKey(final Object id, final Class<?> clazz) {
         this.id = id;
-        this.entityClass = new EntityClass<>(clazz);
+        this.clazz = clazz;
     }
 
     public EntityKey(final Object id, final Object object) {
@@ -23,11 +21,11 @@ public class EntityKey {
         if (this == entity) return true;
         if (entity == null || getClass() != entity.getClass()) return false;
         EntityKey entityKey = (EntityKey) entity;
-        return Objects.equals(id, entityKey.id) && Objects.equals(entityClass, entityKey.entityClass);
+        return Objects.equals(id, entityKey.id) && Objects.equals(clazz, entityKey.clazz);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, entityClass);
+        return Objects.hash(id, clazz);
     }
 }

--- a/src/main/java/hibernate/entity/persistencecontext/EntitySnapshot.java
+++ b/src/main/java/hibernate/entity/persistencecontext/EntitySnapshot.java
@@ -17,7 +17,7 @@ public class EntitySnapshot {
     }
 
     private Map<EntityColumn, Object> parseToSnapshot(final Object entity) {
-        return EntityClass.getInstance(entity.getClass())
+        return new EntityClass<>(entity.getClass())
                 .getEntityColumns()
                 .stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/hibernate/metamodel/MetaModel.java
+++ b/src/main/java/hibernate/metamodel/MetaModel.java
@@ -1,0 +1,10 @@
+package hibernate.metamodel;
+
+import hibernate.entity.meta.EntityClass;
+
+import java.util.Map;
+
+public interface MetaModel {
+
+    Map<Class<?>, EntityClass<?>> getEntityClasses();
+}

--- a/src/main/java/hibernate/metamodel/MetaModel.java
+++ b/src/main/java/hibernate/metamodel/MetaModel.java
@@ -7,4 +7,6 @@ import java.util.Map;
 public interface MetaModel {
 
     Map<Class<?>, EntityClass<?>> getEntityClasses();
+
+    <T> EntityClass<T> getEntityClass(Class<T> clazz);
 }

--- a/src/main/java/hibernate/metamodel/MetaModel.java
+++ b/src/main/java/hibernate/metamodel/MetaModel.java
@@ -1,5 +1,7 @@
 package hibernate.metamodel;
 
+import hibernate.entity.EntityLoader;
+import hibernate.entity.EntityPersister;
 import hibernate.entity.meta.EntityClass;
 
 import java.util.Map;
@@ -9,4 +11,8 @@ public interface MetaModel {
     Map<Class<?>, EntityClass<?>> getEntityClasses();
 
     <T> EntityClass<T> getEntityClass(Class<T> clazz);
+
+    <T> EntityPersister<T> getEntityPersister(Class<T> clazz);
+
+    <T> EntityLoader<T> getEntityLoader(Class<T> clazz);
 }

--- a/src/main/java/hibernate/metamodel/MetaModel.java
+++ b/src/main/java/hibernate/metamodel/MetaModel.java
@@ -2,11 +2,11 @@ package hibernate.metamodel;
 
 import hibernate.entity.EntityLoader;
 import hibernate.entity.EntityPersister;
-import hibernate.entity.meta.EntityClass;
+import hibernate.entity.meta.column.EntityColumn;
 
 public interface MetaModel {
 
-    <T> EntityClass<T> getEntityClass(Class<T> clazz);
+    EntityColumn getEntityId(Class<?> clazz);
 
     <T> EntityPersister<T> getEntityPersister(Class<T> clazz);
 

--- a/src/main/java/hibernate/metamodel/MetaModel.java
+++ b/src/main/java/hibernate/metamodel/MetaModel.java
@@ -4,11 +4,7 @@ import hibernate.entity.EntityLoader;
 import hibernate.entity.EntityPersister;
 import hibernate.entity.meta.EntityClass;
 
-import java.util.Map;
-
 public interface MetaModel {
-
-    Map<Class<?>, EntityClass<?>> getEntityClasses();
 
     <T> EntityClass<T> getEntityClass(Class<T> clazz);
 

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -4,6 +4,7 @@ import hibernate.binder.AnnotationBinder;
 import hibernate.entity.EntityLoader;
 import hibernate.entity.EntityPersister;
 import hibernate.entity.meta.EntityClass;
+import hibernate.entity.meta.column.EntityColumn;
 import jdbc.JdbcTemplate;
 
 import java.util.List;
@@ -41,9 +42,10 @@ public class MetaModelImpl implements MetaModel {
     }
 
     @Override
-    public <T> EntityClass<T> getEntityClass(final Class<T> clazz) {
+    public EntityColumn getEntityId(final Class<?> clazz) {
         if (entityClassMap.containsKey(clazz)) {
-            return (EntityClass<T>) entityClassMap.get(clazz);
+            return entityClassMap.get(clazz)
+                    .getEntityId();
         }
         throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
     }

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -28,7 +28,7 @@ public class MetaModelImpl implements MetaModel {
     }
 
     @Override
-    public <T> EntityClass<T> getEntityClass(Class<T> clazz) {
+    public <T> EntityClass<T> getEntityClass(final Class<T> clazz) {
         if (entityClassMap.containsKey(clazz)) {
             return (EntityClass<T>) entityClassMap.get(clazz);
         }

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -18,7 +18,7 @@ public class MetaModelImpl implements MetaModel {
     public static MetaModel createPackageMetaModel(final String packageName) {
         Map<Class<?>, EntityClass<?>> entityClassMap = AnnotationBinder.parseEntityClasses(packageName)
                 .stream()
-                .collect(Collectors.toMap(clazz -> clazz, EntityClass::getInstance));
+                .collect(Collectors.toMap(clazz -> clazz, EntityClass::new));
         return new MetaModelImpl(entityClassMap);
     }
 

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -26,4 +26,12 @@ public class MetaModelImpl implements MetaModel {
     public Map<Class<?>, EntityClass<?>> getEntityClasses() {
         return Collections.unmodifiableMap(entityClassMap);
     }
+
+    @Override
+    public <T> EntityClass<T> getEntityClass(Class<T> clazz) {
+        if (entityClassMap.containsKey(clazz)) {
+            return (EntityClass<T>) entityClassMap.get(clazz);
+        }
+        throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
+    }
 }

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -6,7 +6,6 @@ import hibernate.entity.EntityPersister;
 import hibernate.entity.meta.EntityClass;
 import jdbc.JdbcTemplate;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,11 +38,6 @@ public class MetaModelImpl implements MetaModel {
                 .stream()
                 .collect(Collectors.toMap(clazz -> clazz, clazz -> new EntityLoader<>(jdbcTemplate, entityClassMap.get(clazz))));
         return new MetaModelImpl(entityClassMap, entityPersisterMap, entityLoaderMap);
-    }
-
-    @Override
-    public Map<Class<?>, EntityClass<?>> getEntityClasses() {
-        return Collections.unmodifiableMap(entityClassMap);
     }
 
     @Override

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -1,0 +1,29 @@
+package hibernate.metamodel;
+
+import hibernate.binder.AnnotationBinder;
+import hibernate.entity.meta.EntityClass;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MetaModelImpl implements MetaModel {
+
+    private final Map<Class<?>, EntityClass<?>> entityClassMap;
+
+    private MetaModelImpl(final Map<Class<?>, EntityClass<?>> entityClassMap) {
+        this.entityClassMap = entityClassMap;
+    }
+
+    public static MetaModel createPackageMetaModel(final String packageName) {
+        Map<Class<?>, EntityClass<?>> entityClassMap = AnnotationBinder.parseEntityClasses(packageName)
+                .stream()
+                .collect(Collectors.toMap(clazz -> clazz, EntityClass::getInstance));
+        return new MetaModelImpl(entityClassMap);
+    }
+
+    @Override
+    public Map<Class<?>, EntityClass<?>> getEntityClasses() {
+        return Collections.unmodifiableMap(entityClassMap);
+    }
+}

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -1,25 +1,44 @@
 package hibernate.metamodel;
 
 import hibernate.binder.AnnotationBinder;
+import hibernate.entity.EntityLoader;
+import hibernate.entity.EntityPersister;
 import hibernate.entity.meta.EntityClass;
+import jdbc.JdbcTemplate;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class MetaModelImpl implements MetaModel {
 
     private final Map<Class<?>, EntityClass<?>> entityClassMap;
+    private final Map<Class<?>, EntityPersister<?>> entityPersisterMap;
+    private final Map<Class<?>, EntityLoader<?>> entityLoaderMap;
 
-    private MetaModelImpl(final Map<Class<?>, EntityClass<?>> entityClassMap) {
+    private MetaModelImpl(
+            final Map<Class<?>, EntityClass<?>> entityClassMap,
+            final Map<Class<?>, EntityPersister<?>> entityPersisterMap,
+            final Map<Class<?>, EntityLoader<?>> entityLoaderMap
+    ) {
         this.entityClassMap = entityClassMap;
+        this.entityPersisterMap = entityPersisterMap;
+        this.entityLoaderMap = entityLoaderMap;
     }
 
-    public static MetaModel createPackageMetaModel(final String packageName) {
-        Map<Class<?>, EntityClass<?>> entityClassMap = AnnotationBinder.parseEntityClasses(packageName)
+    public static MetaModel createPackageMetaModel(final String packageName, final JdbcTemplate jdbcTemplate) {
+        List<Class<?>> classes = AnnotationBinder.parseEntityClasses(packageName);
+        Map<Class<?>, EntityClass<?>> entityClassMap = classes
                 .stream()
                 .collect(Collectors.toMap(clazz -> clazz, EntityClass::new));
-        return new MetaModelImpl(entityClassMap);
+        Map<Class<?>, EntityPersister<?>> entityPersisterMap = classes
+                .stream()
+                .collect(Collectors.toMap(clazz -> clazz, clazz -> new EntityPersister<>(jdbcTemplate, entityClassMap.get(clazz))));
+        Map<Class<?>, EntityLoader<?>> entityLoaderMap = classes
+                .stream()
+                .collect(Collectors.toMap(clazz -> clazz, clazz -> new EntityLoader<>(jdbcTemplate, entityClassMap.get(clazz))));
+        return new MetaModelImpl(entityClassMap, entityPersisterMap, entityLoaderMap);
     }
 
     @Override
@@ -31,6 +50,24 @@ public class MetaModelImpl implements MetaModel {
     public <T> EntityClass<T> getEntityClass(final Class<T> clazz) {
         if (entityClassMap.containsKey(clazz)) {
             return (EntityClass<T>) entityClassMap.get(clazz);
+        }
+        throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
+    }
+
+    // TODO 테스트 추가
+    @Override
+    public <T> EntityPersister<T> getEntityPersister(Class<T> clazz) {
+        if (entityPersisterMap.containsKey(clazz)) {
+            return (EntityPersister<T>) entityPersisterMap.get(clazz);
+        }
+        throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
+    }
+
+    // TODO 테스트 추가
+    @Override
+    public <T> EntityLoader<T> getEntityLoader(Class<T> clazz) {
+        if (entityPersisterMap.containsKey(clazz)) {
+            return (EntityLoader<T>) entityLoaderMap.get(clazz);
         }
         throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
     }

--- a/src/main/java/hibernate/metamodel/MetaModelImpl.java
+++ b/src/main/java/hibernate/metamodel/MetaModelImpl.java
@@ -54,7 +54,6 @@ public class MetaModelImpl implements MetaModel {
         throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
     }
 
-    // TODO 테스트 추가
     @Override
     public <T> EntityPersister<T> getEntityPersister(Class<T> clazz) {
         if (entityPersisterMap.containsKey(clazz)) {
@@ -63,7 +62,6 @@ public class MetaModelImpl implements MetaModel {
         throw new IllegalArgumentException("해당 클래스는 엔티티 클래스가 아닙니다.");
     }
 
-    // TODO 테스트 추가
     @Override
     public <T> EntityLoader<T> getEntityLoader(Class<T> clazz) {
         if (entityPersisterMap.containsKey(clazz)) {

--- a/src/main/java/repository/CustomJpaRepository.java
+++ b/src/main/java/repository/CustomJpaRepository.java
@@ -18,7 +18,7 @@ public class CustomJpaRepository<T, ID> {
     }
 
     private boolean isNewEntity(T t) {
-        return EntityClass.getInstance(t.getClass())
+        return new EntityClass<>(t.getClass())
                 .getEntityId()
                 .getFieldValue(t) == null;
     }

--- a/src/test/java/hibernate/binder/AnnotationBinderTest.java
+++ b/src/test/java/hibernate/binder/AnnotationBinderTest.java
@@ -25,7 +25,7 @@ class AnnotationBinderTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
 
         @Id
         private Long id;

--- a/src/test/java/hibernate/binder/AnnotationBinderTest.java
+++ b/src/test/java/hibernate/binder/AnnotationBinderTest.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,9 +13,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AnnotationBinderTest {
 
     @Test
-    void Entity_어노테이션이_달린_클래스를_가져온다() throws IOException, ClassNotFoundException {
+    void Entity_어노테이션이_달린_클래스를_가져온다() {
         List<Class<?>> actual = AnnotationBinder.parseEntityClasses("hibernate.binder");
         assertThat(actual).containsOnly(Entity1.class, Entity2.class, TestEntity.class);
+    }
+
+    @Test
+    void Entity_어노테이션이_있는_클래스가_없는_경우_빈리스트를_반환한다() {
+        List<Class<?>> actual = AnnotationBinder.parseEntityClasses("hibernate.binder.empty");
+        assertThat(actual).isEmpty();
     }
 
     @Entity

--- a/src/test/java/hibernate/binder/AnnotationBinderTest.java
+++ b/src/test/java/hibernate/binder/AnnotationBinderTest.java
@@ -1,0 +1,28 @@
+package hibernate.binder;
+
+import hibernate.binder.entity.Entity1;
+import hibernate.binder.entity.Entity2;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnnotationBinderTest {
+
+    @Test
+    void Entity_어노테이션이_달린_클래스를_가져온다() throws IOException, ClassNotFoundException {
+        List<Class<?>> actual = AnnotationBinder.parseEntityClasses("hibernate.binder");
+        assertThat(actual).containsOnly(Entity1.class, Entity2.class, TestEntity.class);
+    }
+
+    @Entity
+    static class TestEntity {
+
+        @Id
+        private Long id;
+    }
+}

--- a/src/test/java/hibernate/binder/empty/NoEntity.java
+++ b/src/test/java/hibernate/binder/empty/NoEntity.java
@@ -1,0 +1,4 @@
+package hibernate.binder.empty;
+
+public class NoEntity {
+}

--- a/src/test/java/hibernate/binder/entity/Entity1.java
+++ b/src/test/java/hibernate/binder/entity/Entity1.java
@@ -1,0 +1,11 @@
+package hibernate.binder.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Entity1 {
+
+    @Id
+    private Long id;
+}

--- a/src/test/java/hibernate/binder/entity/Entity2.java
+++ b/src/test/java/hibernate/binder/entity/Entity2.java
@@ -1,0 +1,11 @@
+package hibernate.binder.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Entity2 {
+
+    @Id
+    private Long id;
+}

--- a/src/test/java/hibernate/binder/entity/NoEntity.java
+++ b/src/test/java/hibernate/binder/entity/NoEntity.java
@@ -1,0 +1,4 @@
+package hibernate.binder.entity;
+
+public class NoEntity {
+}

--- a/src/test/java/hibernate/ddl/CreateQueryBuilderTest.java
+++ b/src/test/java/hibernate/ddl/CreateQueryBuilderTest.java
@@ -21,7 +21,7 @@ class CreateQueryBuilderTest {
         List<String> expectedColumns = List.of("id bigint", "age integer", "name varchar");
 
         // when
-        String actual = createQueryBuilder.generateQuery(EntityClass.getInstance(Person.class))
+        String actual = createQueryBuilder.generateQuery(new EntityClass<>(Person.class))
                 .toLowerCase();
 
         // then
@@ -37,7 +37,7 @@ class CreateQueryBuilderTest {
         String expectedColumn = "id bigint primary key";
 
         // when
-        String actual = createQueryBuilder.generateQuery((EntityClass.getInstance(Person.class)));
+        String actual = createQueryBuilder.generateQuery((new EntityClass<>(Person.class)));
 
         // then
         assertThat(actual).contains(expectedColumn);
@@ -49,7 +49,7 @@ class CreateQueryBuilderTest {
         List<String> expectedColumns = List.of("nick_name varchar", "old integer", "email varchar");
 
         // when
-        String actual = createQueryBuilder.generateQuery(EntityClass.getInstance(Person2.class))
+        String actual = createQueryBuilder.generateQuery(new EntityClass<>(Person2.class))
                 .toLowerCase();
 
         // then
@@ -62,7 +62,7 @@ class CreateQueryBuilderTest {
         String expectedColumn = "email varchar not null";
 
         // when
-        String actual = createQueryBuilder.generateQuery(EntityClass.getInstance(Person2.class))
+        String actual = createQueryBuilder.generateQuery(new EntityClass<>(Person2.class))
                 .toLowerCase();
 
         // then
@@ -75,7 +75,7 @@ class CreateQueryBuilderTest {
         String expectedColumn = "id bigint primary key auto_increment";
 
         // when
-        String actual = createQueryBuilder.generateQuery(EntityClass.getInstance(Person2.class))
+        String actual = createQueryBuilder.generateQuery(new EntityClass<>(Person2.class))
                 .toLowerCase();
 
         // then
@@ -88,7 +88,7 @@ class CreateQueryBuilderTest {
         String expected = "create table users";
 
         // when
-        String actual = createQueryBuilder.generateQuery(EntityClass.getInstance(Person3.class))
+        String actual = createQueryBuilder.generateQuery(new EntityClass<>(Person3.class))
                 .toLowerCase();
 
         // then
@@ -101,7 +101,7 @@ class CreateQueryBuilderTest {
         String expected = "index integer";
 
         // when
-        String actual = createQueryBuilder.generateQuery(EntityClass.getInstance(Person3.class))
+        String actual = createQueryBuilder.generateQuery(new EntityClass<>(Person3.class))
                 .toLowerCase();
 
         // then

--- a/src/test/java/hibernate/ddl/DropQueryBuilderTest.java
+++ b/src/test/java/hibernate/ddl/DropQueryBuilderTest.java
@@ -17,7 +17,7 @@ class DropQueryBuilderTest {
     @Test
     void drop쿼리를_생성한다() {
         Pattern expected = Pattern.compile("drop table testentity");
-        String actual = dropQueryBuilder.generateQuery(EntityClass.getInstance(TestEntity.class))
+        String actual = dropQueryBuilder.generateQuery(new EntityClass<>(TestEntity.class))
                 .toLowerCase();
         assertThat(actual).matches(expected);
     }
@@ -25,7 +25,7 @@ class DropQueryBuilderTest {
     @Test
     void Table어노테이션이_있는_경우_해당_이름으로_drop쿼리를_생성한다() {
         Pattern expected = Pattern.compile("drop table table_option");
-        String actual = dropQueryBuilder.generateQuery(EntityClass.getInstance(TestEntity2.class))
+        String actual = dropQueryBuilder.generateQuery(new EntityClass<>(TestEntity2.class))
                 .toLowerCase();
         assertThat(actual).matches(expected);
     }

--- a/src/test/java/hibernate/ddl/DropQueryBuilderTest.java
+++ b/src/test/java/hibernate/ddl/DropQueryBuilderTest.java
@@ -31,7 +31,7 @@ class DropQueryBuilderTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
     }

--- a/src/test/java/hibernate/ddl/strategy/IdIdentityOptionGenerateStrategyTest.java
+++ b/src/test/java/hibernate/ddl/strategy/IdIdentityOptionGenerateStrategyTest.java
@@ -41,7 +41,7 @@ class IdIdentityOptionGenerateStrategyTest {
         assertThat(actual).isEqualTo("auto_increment");
     }
 
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id1;

--- a/src/test/java/hibernate/ddl/strategy/NotNullOptionGenerateStrategyTest.java
+++ b/src/test/java/hibernate/ddl/strategy/NotNullOptionGenerateStrategyTest.java
@@ -39,7 +39,7 @@ class NotNullOptionGenerateStrategyTest {
         assertThat(actual).isEqualTo("not null");
     }
 
-    static class TestEntity {
+    private static class TestEntity {
         @Column(nullable = false)
         private String name1;
 

--- a/src/test/java/hibernate/ddl/strategy/PrimaryKetOptionGenerateStrategyTest.java
+++ b/src/test/java/hibernate/ddl/strategy/PrimaryKetOptionGenerateStrategyTest.java
@@ -37,7 +37,7 @@ class PrimaryKetOptionGenerateStrategyTest {
         assertThat(actual).isEqualTo("primary key");
     }
 
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id1;
 

--- a/src/test/java/hibernate/dml/DeleteQueryBuilderTest.java
+++ b/src/test/java/hibernate/dml/DeleteQueryBuilderTest.java
@@ -24,7 +24,7 @@ class DeleteQueryBuilderTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
 
         @Id
         private Long id;

--- a/src/test/java/hibernate/dml/InsertQueryBuilderTest.java
+++ b/src/test/java/hibernate/dml/InsertQueryBuilderTest.java
@@ -32,7 +32,7 @@ class InsertQueryBuilderTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
 
         @Id
         private Long id;

--- a/src/test/java/hibernate/dml/SelectQueryBuilderTest.java
+++ b/src/test/java/hibernate/dml/SelectQueryBuilderTest.java
@@ -86,7 +86,7 @@ class SelectQueryBuilderTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
 
         @Id
         private Long id;

--- a/src/test/java/hibernate/dml/UpdateQueryBuilderTest.java
+++ b/src/test/java/hibernate/dml/UpdateQueryBuilderTest.java
@@ -19,8 +19,8 @@ class UpdateQueryBuilderTest {
         // given
         Map<EntityColumn, Object> fieldValues = new LinkedHashMap<>();
         EntityField entityId = new EntityField(TestEntity.class.getDeclaredField("id"));
-        fieldValues.put(new EntityField(InsertQueryBuilderTest.TestEntity.class.getDeclaredField("id")), 1);
-        fieldValues.put(new EntityField(InsertQueryBuilderTest.TestEntity.class.getDeclaredField("name")), "최진영");
+        fieldValues.put(new EntityField(TestEntity.class.getDeclaredField("id")), 1);
+        fieldValues.put(new EntityField(TestEntity.class.getDeclaredField("name")), "최진영");
         String expected = "update test_entity set id = 1, nick_name = '최진영' where id = 1;";
 
         // when
@@ -32,7 +32,7 @@ class UpdateQueryBuilderTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
 
         @Id
         private Long id;

--- a/src/test/java/hibernate/entity/EntityLoaderTest.java
+++ b/src/test/java/hibernate/entity/EntityLoaderTest.java
@@ -30,7 +30,7 @@ class EntityLoaderTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
 
-        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(EntityClass.getInstance(EntityManagerImplTest.TestEntity.class)));
+        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(new EntityClass<>(EntityManagerImplTest.TestEntity.class)));
         jdbcTemplate.execute("CREATE TABLE orders (\n" +
                 "    id BIGINT PRIMARY KEY,\n" +
                 "    orderNumber VARCHAR\n" +
@@ -72,7 +72,7 @@ class EntityLoaderTest {
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (1, '최진영', 19)");
 
         // when
-        TestEntity actual = entityLoader.find(EntityClass.getInstance(TestEntity.class), 1L);
+        TestEntity actual = entityLoader.find(new EntityClass<>(TestEntity.class), 1L);
 
         // then
         assertAll(
@@ -93,7 +93,7 @@ class EntityLoaderTest {
         jdbcTemplate.execute("insert into lazy_order_items (id, lazy_order_id, product, quantity) values (3, 1, '바나나', 4);");
 
         // when
-        Order actual = entityLoader.find(EntityClass.getInstance(Order.class), 1L);
+        Order actual = entityLoader.find(new EntityClass<>(Order.class), 1L);
 
         // then
         assertAll(
@@ -110,7 +110,7 @@ class EntityLoaderTest {
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (2, '진영최', 29)");
 
         // when
-        List<TestEntity> actual = entityLoader.findAll(EntityClass.getInstance(TestEntity.class));
+        List<TestEntity> actual = entityLoader.findAll(new EntityClass<>(TestEntity.class));
 
         // then
         assertThat(actual).hasSize(2);

--- a/src/test/java/hibernate/entity/EntityLoaderTest.java
+++ b/src/test/java/hibernate/entity/EntityLoaderTest.java
@@ -29,7 +29,7 @@ class EntityLoaderTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
 
-        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(new EntityClass<>(EntityManagerImplTest.TestEntity.class)));
+        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(new EntityClass<>(TestEntity.class)));
         jdbcTemplate.execute("CREATE TABLE orders (\n" +
                 "    id BIGINT PRIMARY KEY,\n" +
                 "    orderNumber VARCHAR\n" +
@@ -122,7 +122,7 @@ class EntityLoaderTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;

--- a/src/test/java/hibernate/entity/EntityLoaderTest.java
+++ b/src/test/java/hibernate/entity/EntityLoaderTest.java
@@ -22,7 +22,6 @@ class EntityLoaderTest {
 
     private static DatabaseServer server;
     private static JdbcTemplate jdbcTemplate;
-    private final EntityLoader entityLoader = new EntityLoader(jdbcTemplate);
 
     @BeforeAll
     static void beforeAll() throws SQLException {
@@ -70,9 +69,10 @@ class EntityLoaderTest {
     void find_쿼리를_실행한다() {
         // given
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (1, '최진영', 19)");
+        EntityLoader<TestEntity> entityLoader = new EntityLoader<>(jdbcTemplate, new EntityClass<>(TestEntity.class));
 
         // when
-        TestEntity actual = entityLoader.find(new EntityClass<>(TestEntity.class), 1L);
+        TestEntity actual = entityLoader.find(1L);
 
         // then
         assertAll(
@@ -92,8 +92,10 @@ class EntityLoaderTest {
         jdbcTemplate.execute("insert into lazy_order_items (id, lazy_order_id, product, quantity) values (2, 1, '김치', 2);");
         jdbcTemplate.execute("insert into lazy_order_items (id, lazy_order_id, product, quantity) values (3, 1, '바나나', 4);");
 
+        EntityLoader<Order> entityLoader = new EntityLoader<>(jdbcTemplate, new EntityClass<>(Order.class));
+
         // when
-        Order actual = entityLoader.find(new EntityClass<>(Order.class), 1L);
+        Order actual = entityLoader.find(1L);
 
         // then
         assertAll(
@@ -109,8 +111,10 @@ class EntityLoaderTest {
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (1, '최진영', 19)");
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (2, '진영최', 29)");
 
+        EntityLoader<TestEntity> entityLoader = new EntityLoader<>(jdbcTemplate, new EntityClass<>(TestEntity.class));
+
         // when
-        List<TestEntity> actual = entityLoader.findAll(new EntityClass<>(TestEntity.class));
+        List<TestEntity> actual = entityLoader.findAll();
 
         // then
         assertThat(actual).hasSize(2);

--- a/src/test/java/hibernate/entity/EntityManagerImplTest.java
+++ b/src/test/java/hibernate/entity/EntityManagerImplTest.java
@@ -53,7 +53,7 @@ class EntityManagerImplTest {
         server = new H2();
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
-        jdbcTemplate.execute(createQueryBuilder.generateQuery(EntityClass.getInstance(TestEntity.class)));
+        jdbcTemplate.execute(createQueryBuilder.generateQuery(new EntityClass<>(TestEntity.class)));
     }
 
     @AfterEach
@@ -138,7 +138,7 @@ class EntityManagerImplTest {
 
         // when
         entityManager.persist(givenEntity);
-        TestEntity actual = jdbcTemplate.queryForObject("select id, nick_name, age from test_entity;", ReflectionRowMapper.getInstance(EntityClass.getInstance(TestEntity.class)));
+        TestEntity actual = jdbcTemplate.queryForObject("select id, nick_name, age from test_entity;", ReflectionRowMapper.getInstance(new EntityClass<>(TestEntity.class)));
         TestEntity actualPersistenceContext = (TestEntity) persistenceContextEntities.get(new EntityKey(actual.id, TestEntity.class));
 
         // then

--- a/src/test/java/hibernate/entity/EntityManagerImplTest.java
+++ b/src/test/java/hibernate/entity/EntityManagerImplTest.java
@@ -9,6 +9,7 @@ import hibernate.entity.meta.EntityClass;
 import hibernate.entity.persistencecontext.EntityKey;
 import hibernate.entity.persistencecontext.EntitySnapshot;
 import hibernate.entity.persistencecontext.SimplePersistenceContext;
+import hibernate.metamodel.MetaModelImpl;
 import jakarta.persistence.*;
 import jdbc.JdbcTemplate;
 import jdbc.ReflectionRowMapper;
@@ -44,7 +45,8 @@ class EntityManagerImplTest {
         entityManager = new EntityManagerImpl(
                 new EntityPersister(jdbcTemplate),
                 new EntityLoader(jdbcTemplate),
-                new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(entityEntryContextEntities))
+                new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(entityEntryContextEntities)),
+                MetaModelImpl.createPackageMetaModel("hibernate.entity")
         );
     }
 

--- a/src/test/java/hibernate/entity/EntityManagerImplTest.java
+++ b/src/test/java/hibernate/entity/EntityManagerImplTest.java
@@ -251,7 +251,7 @@ class EntityManagerImplTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;

--- a/src/test/java/hibernate/entity/EntityManagerImplTest.java
+++ b/src/test/java/hibernate/entity/EntityManagerImplTest.java
@@ -43,10 +43,8 @@ class EntityManagerImplTest {
         persistenceContextSnapshotEntities = new ConcurrentHashMap<>();
         entityEntryContextEntities = new ConcurrentHashMap<>();
         entityManager = new EntityManagerImpl(
-                new EntityPersister(jdbcTemplate),
-                new EntityLoader(jdbcTemplate),
                 new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(entityEntryContextEntities)),
-                MetaModelImpl.createPackageMetaModel("hibernate.entity")
+                MetaModelImpl.createPackageMetaModel("hibernate.entity", jdbcTemplate)
         );
     }
 

--- a/src/test/java/hibernate/entity/EntityManagerImplTest.java
+++ b/src/test/java/hibernate/entity/EntityManagerImplTest.java
@@ -8,7 +8,9 @@ import hibernate.entity.entityentry.EntityEntryContext;
 import hibernate.entity.meta.EntityClass;
 import hibernate.entity.persistencecontext.EntityKey;
 import hibernate.entity.persistencecontext.EntitySnapshot;
+import hibernate.entity.persistencecontext.PersistenceContext;
 import hibernate.entity.persistencecontext.SimplePersistenceContext;
+import hibernate.metamodel.MetaModel;
 import hibernate.metamodel.MetaModelImpl;
 import jakarta.persistence.*;
 import jdbc.JdbcTemplate;
@@ -42,10 +44,10 @@ class EntityManagerImplTest {
         persistenceContextEntities = new ConcurrentHashMap<>();
         persistenceContextSnapshotEntities = new ConcurrentHashMap<>();
         entityEntryContextEntities = new ConcurrentHashMap<>();
-        entityManager = new EntityManagerImpl(
-                new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(entityEntryContextEntities)),
-                MetaModelImpl.createPackageMetaModel("hibernate.entity", jdbcTemplate)
-        );
+        EntityEntryContext entityEntryContext = new EntityEntryContext(entityEntryContextEntities);
+        PersistenceContext persistenceContext = new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, entityEntryContext);
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.entity", jdbcTemplate);
+        entityManager = new EntityManagerImpl(persistenceContext, metaModel);
     }
 
     @BeforeAll

--- a/src/test/java/hibernate/entity/EntityPersisterTest.java
+++ b/src/test/java/hibernate/entity/EntityPersisterTest.java
@@ -30,7 +30,7 @@ class EntityPersisterTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
 
-        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(EntityClass.getInstance(TestEntity.class)));
+        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(new EntityClass<>(TestEntity.class)));
     }
 
     @AfterEach
@@ -47,7 +47,7 @@ class EntityPersisterTest {
     @Test
     void update_쿼리를_실행한다() {
         // given
-        EntityClass<TestEntity> entityClass = EntityClass.getInstance(TestEntity.class);
+        EntityClass<TestEntity> entityClass = new EntityClass<>(TestEntity.class);
         jdbcTemplate.execute("insert into test_entity (id, nick_name) values (1, '최진영');");
 
         // when

--- a/src/test/java/hibernate/entity/EntityPersisterTest.java
+++ b/src/test/java/hibernate/entity/EntityPersisterTest.java
@@ -101,7 +101,7 @@ class EntityPersisterTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;

--- a/src/test/java/hibernate/entity/EntityPersisterTest.java
+++ b/src/test/java/hibernate/entity/EntityPersisterTest.java
@@ -22,7 +22,6 @@ class EntityPersisterTest {
 
     private static DatabaseServer server;
     private static JdbcTemplate jdbcTemplate;
-    private final EntityPersister entityPersister = new EntityPersister(jdbcTemplate);
 
     @BeforeAll
     static void beforeAll() throws SQLException {
@@ -48,10 +47,11 @@ class EntityPersisterTest {
     void update_쿼리를_실행한다() {
         // given
         EntityClass<TestEntity> entityClass = new EntityClass<>(TestEntity.class);
+        EntityPersister<TestEntity> entityPersister = new EntityPersister<>(jdbcTemplate, entityClass);
         jdbcTemplate.execute("insert into test_entity (id, nick_name) values (1, '최진영');");
 
         // when
-        boolean actual = entityPersister.update(entityClass, 1L, Map.of(entityClass.getEntityColumns().get(1), "영진최"));
+        boolean actual = entityPersister.update(1L, Map.of(entityClass.getEntityColumns().get(1), "영진최"));
 
         // then
         assertThat(actual).isTrue();
@@ -61,6 +61,7 @@ class EntityPersisterTest {
     void insert_쿼리를_실행한다() {
         // given
         TestEntity givenEntity = new TestEntity("최진영");
+        EntityPersister<TestEntity> entityPersister = new EntityPersister<>(jdbcTemplate, new EntityClass<>(TestEntity.class));
 
         // when
         entityPersister.insert(givenEntity);
@@ -74,6 +75,7 @@ class EntityPersisterTest {
     void delete_쿼리를_실행한다() {
         // given
         TestEntity givenEntity = new TestEntity(1L, "최진영");
+        EntityPersister<TestEntity> entityPersister = new EntityPersister<>(jdbcTemplate, new EntityClass<>(TestEntity.class));
         jdbcTemplate.execute("insert into test_entity (id, nick_name) values (1, '최진영');");
 
         // when

--- a/src/test/java/hibernate/entity/collection/PersistentListTest.java
+++ b/src/test/java/hibernate/entity/collection/PersistentListTest.java
@@ -19,7 +19,6 @@ class PersistentListTest {
 
     private static DatabaseServer server;
     private static JdbcTemplate jdbcTemplate;
-    private final EntityLoader entityLoader = new EntityLoader(jdbcTemplate);
 
     @BeforeAll
     static void beforeAll() throws SQLException {
@@ -41,6 +40,8 @@ class PersistentListTest {
         // given
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (1, '최진영', 19)");
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (2, '진영최', 29)");
+
+        EntityLoader<TestEntity> entityLoader = new EntityLoader<>(jdbcTemplate, new EntityClass<>(TestEntity.class));
 
         // when
         int actual = new PersistentList<>(new EntityClass<>(TestEntity.class), entityLoader)

--- a/src/test/java/hibernate/entity/collection/PersistentListTest.java
+++ b/src/test/java/hibernate/entity/collection/PersistentListTest.java
@@ -53,7 +53,7 @@ class PersistentListTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;

--- a/src/test/java/hibernate/entity/collection/PersistentListTest.java
+++ b/src/test/java/hibernate/entity/collection/PersistentListTest.java
@@ -27,7 +27,7 @@ class PersistentListTest {
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
 
-        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(EntityClass.getInstance(TestEntity.class)));
+        jdbcTemplate.execute(CreateQueryBuilder.INSTANCE.generateQuery(new EntityClass<>(TestEntity.class)));
     }
 
     @AfterAll
@@ -43,7 +43,7 @@ class PersistentListTest {
         jdbcTemplate.execute("insert into test_entity (id, nick_name, age) values (2, '진영최', 29)");
 
         // when
-        int actual = new PersistentList<>(EntityClass.getInstance(TestEntity.class), entityLoader)
+        int actual = new PersistentList<>(new EntityClass<>(TestEntity.class), entityLoader)
                 .size();
 
         // then

--- a/src/test/java/hibernate/entity/meta/EntityClassTest.java
+++ b/src/test/java/hibernate/entity/meta/EntityClassTest.java
@@ -12,32 +12,32 @@ class EntityClassTest {
 
     @Test
     void Entity_어노테이션이_없으면_생성_시_예외가_발생한다() {
-        assertThatThrownBy(() -> EntityClass.getInstance(EntityClass.class))
+        assertThatThrownBy(() -> new EntityClass<>(EntityClass.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Entity 어노테이션이 없는 클래스는 입력될 수 없습니다.");
     }
 
     @Test
     void Table_어노테이션의_name이_있으면_생성_시_tableName이_된다() {
-        String actual = EntityClass.getInstance(TableEntity.class).tableName();
+        String actual = new EntityClass<>(TableEntity.class).tableName();
         assertThat(actual).isEqualTo("new_table");
     }
 
     @Test
     void Table_어노테이션의_name이_없으면_tableName은_클래스명이_된다() {
-        String actual = EntityClass.getInstance(NoTableEntity.class).tableName();
+        String actual = new EntityClass<>(NoTableEntity.class).tableName();
         assertThat(actual).isEqualTo("NoTableEntity");
     }
 
     @Test
     void 새로운_인스턴스를_생성한다()  {
-        Object actual = EntityClass.getInstance(TableEntity.class).newInstance();
+        Object actual = new EntityClass<>(TableEntity.class).newInstance();
         assertThat(actual).isInstanceOf(TableEntity.class);
     }
 
     @Test
     void 인스턴스_생성_시_기본생성자가_존재하지않으면_예외가_발생한다() {
-        assertThatThrownBy(() -> EntityClass.getInstance(NoConstructorEntity.class).newInstance())
+        assertThatThrownBy(() -> new EntityClass<>(NoConstructorEntity.class).newInstance())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("기본 생성자가 존재하지 않습니다.");
     }

--- a/src/test/java/hibernate/entity/meta/EntityClassTest.java
+++ b/src/test/java/hibernate/entity/meta/EntityClassTest.java
@@ -73,7 +73,7 @@ class EntityClassTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/hibernate/entity/meta/column/EntityColumnTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityColumnTest.java
@@ -55,7 +55,7 @@ class EntityColumnTest {
         assertThat(actual).isInstanceOf(EntityField.class);
     }
 
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/hibernate/entity/meta/column/EntityColumnsTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityColumnsTest.java
@@ -47,7 +47,7 @@ class EntityColumnsTest {
         );
     }
 
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/hibernate/entity/meta/column/EntityFieldTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityFieldTest.java
@@ -106,7 +106,7 @@ class EntityFieldTest {
                 .hasMessage("Entity 객체에 일치하는 필드값이 없습니다.");
     }
 
-    static class TestEntity {
+    private static class TestEntity {
 
         private Long id;
         @Column(name = "nick_name")

--- a/src/test/java/hibernate/entity/meta/column/EntityJoinColumnsTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityJoinColumnsTest.java
@@ -89,7 +89,7 @@ class EntityJoinColumnsTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/hibernate/entity/meta/column/EntityJoinColumnsTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityJoinColumnsTest.java
@@ -22,14 +22,14 @@ class EntityJoinColumnsTest {
     })
     void EAGER가_컬럼에_있는지_확인한다(final String className, final boolean expected) throws ClassNotFoundException {
         Class<?> inputClass = Class.forName(className);
-        boolean actual = oneToManyColumns(EntityClass.getInstance(inputClass))
+        boolean actual = oneToManyColumns(new EntityClass<>(inputClass))
                 .hasEagerFetchType();
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     void oneToMany어노테이션이_달린_Eager컬럼만_가져온다() {
-        List<EntityJoinColumn> actual = oneToManyColumns(EntityClass.getInstance(TestEntity.class))
+        List<EntityJoinColumn> actual = oneToManyColumns(new EntityClass<>(TestEntity.class))
                 .getEagerValues();
         assertAll(
                 () -> assertThat(actual).hasSize(1),
@@ -44,7 +44,7 @@ class EntityJoinColumnsTest {
     })
     void LAZY가_컬럼에_있는지_확인한다(final String className, final boolean expected) throws ClassNotFoundException {
         Class<?> inputClass = Class.forName(className);
-        boolean actual = oneToManyColumns(EntityClass.getInstance(inputClass))
+        boolean actual = oneToManyColumns(new EntityClass<>(inputClass))
                 .hasLazyFetchType();
         assertThat(actual).isEqualTo(expected);
     }
@@ -52,7 +52,7 @@ class EntityJoinColumnsTest {
 
     @Test
     void oneToMany어노테이션이_달린_LAZY컬럼만_가져온다() {
-        List<EntityJoinColumn> actual = oneToManyColumns(EntityClass.getInstance(TestEntity.class))
+        List<EntityJoinColumn> actual = oneToManyColumns(new EntityClass<>(TestEntity.class))
                 .getLazyValues();
         assertAll(
                 () -> assertThat(actual).hasSize(1),
@@ -62,7 +62,7 @@ class EntityJoinColumnsTest {
 
     @Test
     void eager_join테이블의_필드를_가져온다() {
-        Map<String, List<String>> actual = EntityJoinColumns.oneToManyColumns(EntityClass.getInstance(Order.class))
+        Map<String, List<String>> actual = EntityJoinColumns.oneToManyColumns(new EntityClass<>(Order.class))
                 .getEagerJoinTableFields();
 
         assertAll(
@@ -73,7 +73,7 @@ class EntityJoinColumnsTest {
 
     @Test
     void eager_join테이블의_fk필드를_가져온다() {
-        Map<String, Object> actual = EntityJoinColumns.oneToManyColumns(EntityClass.getInstance(Order.class))
+        Map<String, Object> actual = EntityJoinColumns.oneToManyColumns(new EntityClass<>(Order.class))
                 .getEagerJoinTableIds();
 
         assertAll(

--- a/src/test/java/hibernate/entity/meta/column/EntityOneToManyColumnTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityOneToManyColumnTest.java
@@ -27,7 +27,7 @@ class EntityOneToManyColumnTest {
         assertAll(
                 () -> assertThat(actual.getJoinColumnName()).isEqualTo("child_id"),
                 () -> assertThat(actual.getFetchType()).isEqualTo(FetchType.EAGER),
-                () -> assertThat(actual.getEntityClass()).isEqualTo(EntityClass.getInstance(ChildEntity.class))
+                () -> assertThat(actual.getEntityClass()).isEqualTo(new EntityClass<>(ChildEntity.class))
         );
     }
 

--- a/src/test/java/hibernate/entity/meta/column/EntityOneToManyColumnTest.java
+++ b/src/test/java/hibernate/entity/meta/column/EntityOneToManyColumnTest.java
@@ -67,7 +67,7 @@ class EntityOneToManyColumnTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/hibernate/entity/persistencecontext/EntitySnapshotTest.java
+++ b/src/test/java/hibernate/entity/persistencecontext/EntitySnapshotTest.java
@@ -18,7 +18,7 @@ class EntitySnapshotTest {
         TestEntity givenEntity = new TestEntity(1L, "최진영", "jinyoungchoi95@gmail.com");
         EntitySnapshot actual = new EntitySnapshot(givenEntity);
         givenEntity.name = "영진최";
-        EntityColumn entityColumn = EntityClass.getInstance(TestEntity.class)
+        EntityColumn entityColumn = new EntityClass<>(TestEntity.class)
                 .getEntityColumns()
                 .stream()
                 .filter(it -> it.getFieldName() == "name")

--- a/src/test/java/hibernate/entity/persistencecontext/EntitySnapshotTest.java
+++ b/src/test/java/hibernate/entity/persistencecontext/EntitySnapshotTest.java
@@ -51,7 +51,7 @@ class EntitySnapshotTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/hibernate/entity/persistencecontext/SimplePersistenceContextTest.java
+++ b/src/test/java/hibernate/entity/persistencecontext/SimplePersistenceContextTest.java
@@ -93,7 +93,7 @@ class SimplePersistenceContextTest {
     }
 
     @Entity
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;

--- a/src/test/java/hibernate/metamodel/MetaModelImplTest.java
+++ b/src/test/java/hibernate/metamodel/MetaModelImplTest.java
@@ -7,19 +7,10 @@ import hibernate.metamodel.entity.Entity1;
 import hibernate.metamodel.entity.NoEntity;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MetaModelImplTest {
-
-    @Test
-    void 패키지하위의_Entity를_스캔하여_EntityClassMap을_생성한다() {
-        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
-        Map<Class<?>, EntityClass<?>> actual = metaModel.getEntityClasses();
-        assertThat(actual).hasSize(2);
-    }
 
     @Test
     void 패키지하위의_Entity를_스캔하여_EntityClass를_반환한다() {

--- a/src/test/java/hibernate/metamodel/MetaModelImplTest.java
+++ b/src/test/java/hibernate/metamodel/MetaModelImplTest.java
@@ -2,7 +2,7 @@ package hibernate.metamodel;
 
 import hibernate.entity.EntityLoader;
 import hibernate.entity.EntityPersister;
-import hibernate.entity.meta.EntityClass;
+import hibernate.entity.meta.column.EntityColumn;
 import hibernate.metamodel.entity.Entity1;
 import hibernate.metamodel.entity.NoEntity;
 import org.junit.jupiter.api.Test;
@@ -13,16 +13,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class MetaModelImplTest {
 
     @Test
-    void 패키지하위의_Entity를_스캔하여_EntityClass를_반환한다() {
+    void 패키지하위의_Entity를_스캔하여_EntityId를_반환한다() {
         MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
-        EntityClass<?> actual = metaModel.getEntityClass(Entity1.class);
+        EntityColumn actual = metaModel.getEntityId(Entity1.class);
         assertThat(actual).isNotNull();
     }
 
     @Test
-    void Entity가_없는_Class의_EntityClass를_찾으려하는_경우_예외가_발생한다() {
+    void Entity가_없는_Class의_EntityId를_찾으려하는_경우_예외가_발생한다() {
         MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
-        assertThatThrownBy(() -> metaModel.getEntityClass(NoEntity.class))
+        assertThatThrownBy(() -> metaModel.getEntityId(NoEntity.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 클래스는 엔티티 클래스가 아닙니다.");
     }

--- a/src/test/java/hibernate/metamodel/MetaModelImplTest.java
+++ b/src/test/java/hibernate/metamodel/MetaModelImplTest.java
@@ -1,0 +1,18 @@
+package hibernate.metamodel;
+
+import hibernate.entity.meta.EntityClass;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetaModelImplTest {
+
+    @Test
+    void 패키지하위의_Entity를_스캔하여_EntityClassMap을_생성한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
+        Map<Class<?>, EntityClass<?>> actual = metaModel.getEntityClasses();
+        assertThat(actual).hasSize(2);
+    }
+}

--- a/src/test/java/hibernate/metamodel/MetaModelImplTest.java
+++ b/src/test/java/hibernate/metamodel/MetaModelImplTest.java
@@ -1,11 +1,14 @@
 package hibernate.metamodel;
 
 import hibernate.entity.meta.EntityClass;
+import hibernate.metamodel.entity.Entity1;
+import hibernate.metamodel.entity.NoEntity;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MetaModelImplTest {
 
@@ -14,5 +17,20 @@ class MetaModelImplTest {
         MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
         Map<Class<?>, EntityClass<?>> actual = metaModel.getEntityClasses();
         assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    void 패키지하위의_Entity를_스캔하여_EntityClass를_반환한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
+        EntityClass<?> actual = metaModel.getEntityClass(Entity1.class);
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void Entity가_없는_Class의_EntityClass를_찾으려하는_경우_예외가_발생한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
+        assertThatThrownBy(() -> metaModel.getEntityClass(NoEntity.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 클래스는 엔티티 클래스가 아닙니다.");
     }
 }

--- a/src/test/java/hibernate/metamodel/MetaModelImplTest.java
+++ b/src/test/java/hibernate/metamodel/MetaModelImplTest.java
@@ -1,5 +1,7 @@
 package hibernate.metamodel;
 
+import hibernate.entity.EntityLoader;
+import hibernate.entity.EntityPersister;
 import hibernate.entity.meta.EntityClass;
 import hibernate.metamodel.entity.Entity1;
 import hibernate.metamodel.entity.NoEntity;
@@ -14,22 +16,52 @@ class MetaModelImplTest {
 
     @Test
     void 패키지하위의_Entity를_스캔하여_EntityClassMap을_생성한다() {
-        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
         Map<Class<?>, EntityClass<?>> actual = metaModel.getEntityClasses();
         assertThat(actual).hasSize(2);
     }
 
     @Test
     void 패키지하위의_Entity를_스캔하여_EntityClass를_반환한다() {
-        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
         EntityClass<?> actual = metaModel.getEntityClass(Entity1.class);
         assertThat(actual).isNotNull();
     }
 
     @Test
     void Entity가_없는_Class의_EntityClass를_찾으려하는_경우_예외가_발생한다() {
-        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity");
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
         assertThatThrownBy(() -> metaModel.getEntityClass(NoEntity.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 클래스는 엔티티 클래스가 아닙니다.");
+    }
+
+    @Test
+    void 패키지하위의_Entity를_스캔하여_EntityPersister를_반환한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
+        EntityPersister<?> actual = metaModel.getEntityPersister(Entity1.class);
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void Entity가_없는_Class의_EntityPersister를_찾으려하는_경우_예외가_발생한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
+        assertThatThrownBy(() -> metaModel.getEntityPersister(NoEntity.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당 클래스는 엔티티 클래스가 아닙니다.");
+    }
+
+    @Test
+    void 패키지하위의_Entity를_스캔하여_EntityLoader를_반환한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
+        EntityLoader<?> actual = metaModel.getEntityLoader(Entity1.class);
+        assertThat(actual).isNotNull();
+    }
+
+    @Test
+    void Entity가_없는_Class의_EntityLoader를_찾으려하는_경우_예외가_발생한다() {
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("hibernate.metamodel.entity", null);
+        assertThatThrownBy(() -> metaModel.getEntityLoader(NoEntity.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("해당 클래스는 엔티티 클래스가 아닙니다.");
     }

--- a/src/test/java/hibernate/metamodel/entity/Entity1.java
+++ b/src/test/java/hibernate/metamodel/entity/Entity1.java
@@ -1,0 +1,11 @@
+package hibernate.metamodel.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Entity1 {
+
+    @Id
+    private Long id;
+}

--- a/src/test/java/hibernate/metamodel/entity/Entity2.java
+++ b/src/test/java/hibernate/metamodel/entity/Entity2.java
@@ -1,0 +1,11 @@
+package hibernate.metamodel.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Entity2 {
+
+    @Id
+    private Long id;
+}

--- a/src/test/java/hibernate/metamodel/entity/NoEntity.java
+++ b/src/test/java/hibernate/metamodel/entity/NoEntity.java
@@ -1,0 +1,4 @@
+package hibernate.metamodel.entity;
+
+public class NoEntity {
+}

--- a/src/test/java/jdbc/ReflectionRowMapperTest.java
+++ b/src/test/java/jdbc/ReflectionRowMapperTest.java
@@ -41,7 +41,7 @@ class ReflectionRowMapperTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         private Long id;
 

--- a/src/test/java/jdbc/ReflectionRowMapperTest.java
+++ b/src/test/java/jdbc/ReflectionRowMapperTest.java
@@ -24,7 +24,7 @@ class ReflectionRowMapperTest {
         givenResultSet.addColumn("child_entity.age", Types.INTEGER, 0, 0);
         givenResultSet.addRow(1L, "최진영", 3L, 19);
         givenResultSet.next();
-        RowMapper<TestEntity> rowMapper = ReflectionRowMapper.getInstance(EntityClass.getInstance(TestEntity.class));
+        RowMapper<TestEntity> rowMapper = ReflectionRowMapper.getInstance(new EntityClass<>(TestEntity.class));
 
         // when
         TestEntity actual = rowMapper.mapRow(givenResultSet);

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -11,6 +11,7 @@ import hibernate.entity.meta.EntityClass;
 import hibernate.entity.persistencecontext.EntityKey;
 import hibernate.entity.persistencecontext.EntitySnapshot;
 import hibernate.entity.persistencecontext.SimplePersistenceContext;
+import hibernate.metamodel.MetaModelImpl;
 import jakarta.persistence.*;
 import jdbc.JdbcTemplate;
 import jdbc.RowMapper;
@@ -41,7 +42,8 @@ class CustomJpaRepositoryTest {
         entityManager = new EntityManagerImpl(
                 new EntityPersister(jdbcTemplate),
                 new EntityLoader(jdbcTemplate),
-                new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(new ConcurrentHashMap<>()))
+                new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(new ConcurrentHashMap<>())),
+                MetaModelImpl.createPackageMetaModel("repository")
         );
         customJpaRepository = new CustomJpaRepository<>(entityManager);
     }

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -3,12 +3,15 @@ package repository;
 import database.DatabaseServer;
 import database.H2;
 import hibernate.ddl.CreateQueryBuilder;
+import hibernate.entity.EntityManager;
 import hibernate.entity.EntityManagerImpl;
 import hibernate.entity.entityentry.EntityEntryContext;
 import hibernate.entity.meta.EntityClass;
 import hibernate.entity.persistencecontext.EntityKey;
 import hibernate.entity.persistencecontext.EntitySnapshot;
+import hibernate.entity.persistencecontext.PersistenceContext;
 import hibernate.entity.persistencecontext.SimplePersistenceContext;
+import hibernate.metamodel.MetaModel;
 import hibernate.metamodel.MetaModelImpl;
 import jakarta.persistence.*;
 import jdbc.JdbcTemplate;
@@ -27,7 +30,6 @@ class CustomJpaRepositoryTest {
 
     private static DatabaseServer server;
     private static JdbcTemplate jdbcTemplate;
-    private EntityManagerImpl entityManager;
     private Map<EntityKey, Object> persistenceContextEntities;
     private Map<EntityKey, EntitySnapshot> persistenceContextSnapshotEntities;
     private CustomJpaRepository<TestEntity, Long> customJpaRepository;
@@ -37,10 +39,10 @@ class CustomJpaRepositoryTest {
     void beforeEach() {
         persistenceContextEntities = new ConcurrentHashMap<>();
         persistenceContextSnapshotEntities = new ConcurrentHashMap<>();
-        entityManager = new EntityManagerImpl(
-                new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(new ConcurrentHashMap<>())),
-                MetaModelImpl.createPackageMetaModel("repository", jdbcTemplate)
-        );
+        EntityEntryContext entityEntryContext = new EntityEntryContext(new ConcurrentHashMap<>());
+        PersistenceContext persistenceContext = new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, entityEntryContext);
+        MetaModel metaModel = MetaModelImpl.createPackageMetaModel("repository", jdbcTemplate);
+        EntityManager entityManager = new EntityManagerImpl(persistenceContext, metaModel);
         customJpaRepository = new CustomJpaRepository<>(entityManager);
     }
 

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -3,9 +3,7 @@ package repository;
 import database.DatabaseServer;
 import database.H2;
 import hibernate.ddl.CreateQueryBuilder;
-import hibernate.entity.EntityLoader;
 import hibernate.entity.EntityManagerImpl;
-import hibernate.entity.EntityPersister;
 import hibernate.entity.entityentry.EntityEntryContext;
 import hibernate.entity.meta.EntityClass;
 import hibernate.entity.persistencecontext.EntityKey;
@@ -40,10 +38,8 @@ class CustomJpaRepositoryTest {
         persistenceContextEntities = new ConcurrentHashMap<>();
         persistenceContextSnapshotEntities = new ConcurrentHashMap<>();
         entityManager = new EntityManagerImpl(
-                new EntityPersister(jdbcTemplate),
-                new EntityLoader(jdbcTemplate),
                 new SimplePersistenceContext(persistenceContextEntities, persistenceContextSnapshotEntities, new EntityEntryContext(new ConcurrentHashMap<>())),
-                MetaModelImpl.createPackageMetaModel("repository")
+                MetaModelImpl.createPackageMetaModel("repository", jdbcTemplate)
         );
         customJpaRepository = new CustomJpaRepository<>(entityManager);
     }

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -110,7 +110,7 @@ class CustomJpaRepositoryTest {
 
     @Entity
     @Table(name = "test_entity")
-    static class TestEntity {
+    private static class TestEntity {
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;

--- a/src/test/java/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/repository/CustomJpaRepositoryTest.java
@@ -51,7 +51,7 @@ class CustomJpaRepositoryTest {
         server = new H2();
         server.start();
         jdbcTemplate = new JdbcTemplate(server.getConnection());
-        jdbcTemplate.execute(createQueryBuilder.generateQuery(EntityClass.getInstance(TestEntity.class)));
+        jdbcTemplate.execute(createQueryBuilder.generateQuery(new EntityClass<>(TestEntity.class)));
     }
 
     @AfterEach


### PR DESCRIPTION
안녕하세요 정완님 🙂

- `AnnotationBinder`와 `ComponentScanner`은 굳이 상태값을 가진 객체로 존재할 필요는 없어보여 util성 클래스처럼 선언하였어요.


- `EntityPersister`, `EntityLoader`, `EntityClass`
    - `EntityPersister`와 `EntityLoader`는 공통으로 한개씩만 두고 필요할 때마다 각 클래스에서 `EntityClass`를 getInstance하여 사용하는 방식으로 처리했었는데요. 이전에는 `@Entity`에 대한 모든 생성 validation과 비즈니스 로직을 `EntityClass`에서 모든 meta 정보를 쉽게 관리하고 있었고 persister와 loader는 단순히 데이터베이스와 객체의 매핑만을 담당하기 위해서 `EntityManager`당 하나씩 두고 사용하는 방식으로 설계했었어요.
    - 요구사항의 `Metamodel`의 역할과 구조를 보면서 변경이 필요해보였고 기존에는 `EntityClass`가 Entity를 관리하고 있었다면 `Metamodel`에 `AnnotationBinder`를 통해 `@Entity`를 추출하여 persister와 loader를 관리하는 것으로 바꾸었습니다.
    - 그래서 class 마다 persister와 loader를 가지는 형태로 현재 변경하였습니다.

리뷰 잘부탁드립니다 🙇‍♂️